### PR TITLE
Fix compilation error

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,5 +1,5 @@
 [env]
-platform = espressif32
+platform = espressif32 @ 3.0.0
 framework = arduino
 lib_ldf_mode = deep+
 monitor_speed = 115200


### PR DESCRIPTION
compilation error with the espressif32 and the latest version of platform io.
it requires to select a specific version of the espressif32